### PR TITLE
Add an AWS image for runiac

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ A lightweight container with no cloud specific SDKs
 - Runiac
 - Bash, wget, curl, jq, ca-certs
 
+## alpine-aws
+
+An AWS optimized container
+
+- Terraform
+- Runiac
+- AWS CLI v2
+- Bash, wget, curl, jq, ca-certs
+
 ## alpine-azure
 
 An azure optimized container

--- a/build_containers.sh
+++ b/build_containers.sh
@@ -19,4 +19,7 @@ docker buildx build --platform linux/arm64,linux/amd64 -f "package/alpine-azure/
 docker buildx build --platform linux/arm64,linux/amd64 -f "package/alpine-full/Dockerfile" -t "${image_prefix}alpine-full" --push . &
 docker buildx build --platform linux/arm64,linux/amd64 -f "package/alpine-gcp/Dockerfile" -t "${image_prefix}alpine-gcp" --push . &
 
+# TODO: see if we can add support for ARM here as well
+docker buildx build --platform linux/amd64 -f "package/alpine-aws/Dockerfile" -t "${image_prefix}alpine-aws" --push . &
+
 wait

--- a/build_containers.sh
+++ b/build_containers.sh
@@ -15,11 +15,9 @@ image_prefix="runiac/deploy:$VERSION-"
 echo $image_prefix
 
 docker buildx build --build-arg RUNIAC_REF=$REF --platform linux/arm64,linux/amd64 -f "package/alpine/Dockerfile" -t "${image_prefix}alpine" --push . || exit 1
-docker buildx build --platform linux/arm64,linux/amd64 -f "package/alpine-azure/Dockerfile" -t "${image_prefix}alpine-azure" --push . || exit 1
+docker buildx build --platform linux/arm64,linux/amd64 -f "package/alpine-aws/Dockerfile" -t "${image_prefix}alpine-aws" --push . || exit 1
+docker buildx build --platform linux/arm64,linux/amd64 -f "package/alpine-azure/Dockerfile" -t "${image_prefix}alpine-azure" --push . &
 docker buildx build --platform linux/arm64,linux/amd64 -f "package/alpine-full/Dockerfile" -t "${image_prefix}alpine-full" --push . &
 docker buildx build --platform linux/arm64,linux/amd64 -f "package/alpine-gcp/Dockerfile" -t "${image_prefix}alpine-gcp" --push . &
-
-# TODO: see if we can add support for ARM here as well
-docker buildx build --platform linux/amd64 -f "package/alpine-aws/Dockerfile" -t "${image_prefix}alpine-aws" --push . &
 
 wait

--- a/build_containers.sh
+++ b/build_containers.sh
@@ -1,23 +1,32 @@
 #!/bin/bash
+push_containers () {
+    local image_prefix="runiac/deploy:$1-"
+
+    echo $image_prefix
+
+    docker buildx build --build-arg RUNIAC_REF=$REF --platform linux/arm64,linux/amd64 -f "package/alpine/Dockerfile" -t "${image_prefix}alpine" --push . || exit 1
+    docker buildx build --platform linux/arm64,linux/amd64 -f "package/alpine-aws/Dockerfile" -t "${image_prefix}alpine-aws" --push . || exit 1
+    docker buildx build --platform linux/arm64,linux/amd64 -f "package/alpine-azure/Dockerfile" -t "${image_prefix}alpine-azure" --push . &
+    docker buildx build --platform linux/arm64,linux/amd64 -f "package/alpine-full/Dockerfile" -t "${image_prefix}alpine-full" --push . &
+    docker buildx build --platform linux/arm64,linux/amd64 -f "package/alpine-gcp/Dockerfile" -t "${image_prefix}alpine-gcp" --push . &
+
+    wait
+}
 
 # if version not set, set to local default
 if [[ "$REF" == "refs/heads/main" ]]; then
-  VERSION="latest"
+  VERSION="main"
 elif  [[ "$REF" =~ refs/tags/* ]]; then  
   VERSION=$(echo ${REF#refs/tags/})
+  latest="true"
 else
   VERSION=$(whoami)
   REF='refs/heads/main'
 fi
 
-image_prefix="runiac/deploy:$VERSION-"
+push_containers $VERSION
 
-echo $image_prefix
-
-docker buildx build --build-arg RUNIAC_REF=$REF --platform linux/arm64,linux/amd64 -f "package/alpine/Dockerfile" -t "${image_prefix}alpine" --push . || exit 1
-docker buildx build --platform linux/arm64,linux/amd64 -f "package/alpine-aws/Dockerfile" -t "${image_prefix}alpine-aws" --push . || exit 1
-docker buildx build --platform linux/arm64,linux/amd64 -f "package/alpine-azure/Dockerfile" -t "${image_prefix}alpine-azure" --push . &
-docker buildx build --platform linux/arm64,linux/amd64 -f "package/alpine-full/Dockerfile" -t "${image_prefix}alpine-full" --push . &
-docker buildx build --platform linux/arm64,linux/amd64 -f "package/alpine-gcp/Dockerfile" -t "${image_prefix}alpine-gcp" --push . &
-
-wait
+if [[ $latest == "true" ]]
+then
+  push_containers "latest"
+fi

--- a/package/alpine-aws/Dockerfile
+++ b/package/alpine-aws/Dockerfile
@@ -1,0 +1,53 @@
+# syntax = docker/dockerfile:experimental
+
+ARG http_proxy
+ARG https_proxy
+
+FROM python:3-alpine3.13 AS builder
+
+ENV AWSCLI_VERSION=2.2.0
+
+RUN apk add --no-cache \
+    gcc \
+    git \
+    libc-dev \
+    libffi-dev \
+    openssl-dev \
+    py3-pip \
+    zlib-dev \
+    make \
+    cmake
+
+RUN git clone --recursive  --depth 1 --branch ${AWSCLI_VERSION} --single-branch https://github.com/aws/aws-cli.git
+
+WORKDIR /aws-cli
+
+# Follow https://github.com/six8/pyinstaller-alpine to install pyinstaller on alpine
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir pycrypto \
+    && git clone --depth 1 --single-branch --branch v$(grep PyInstaller requirements-build.txt | cut -d'=' -f3) https://github.com/pyinstaller/pyinstaller.git /tmp/pyinstaller \
+    && cd /tmp/pyinstaller/bootloader \
+    && CFLAGS="-Wno-stringop-overflow -Wno-stringop-truncation" python ./waf configure --no-lsb all \
+    && pip install .. \
+    && rm -Rf /tmp/pyinstaller \
+    && cd - \
+    && boto_ver=$(grep botocore setup.cfg | cut -d'=' -f3) \
+    && git clone --single-branch --branch v2 https://github.com/boto/botocore /tmp/botocore \
+    && cd /tmp/botocore \
+    && git checkout $(git log --grep $boto_ver --pretty=format:"%h") \
+    && pip install . \
+    && rm -Rf /tmp/botocore  \
+    && cd -
+
+RUN sed -i '/botocore/d' requirements.txt \
+    && scripts/installers/make-exe
+
+RUN unzip dist/awscli-exe.zip && \
+    ./aws/install --bin-dir /aws-cli-bin
+
+FROM runiac/deploy:latest-alpine AS runner
+
+RUN apk --no-cache add groff
+
+COPY --from=builder /usr/local/aws-cli/ /usr/local/aws-cli/
+COPY --from=builder /aws-cli-bin/ /usr/local/bin/

--- a/package/alpine-aws/Dockerfile
+++ b/package/alpine-aws/Dockerfile
@@ -5,7 +5,7 @@ ARG https_proxy
 
 FROM python:3-alpine3.13 AS builder
 
-ENV AWSCLI_VERSION=2.2.0
+ENV AWSCLI_VERSION=2.2.7
 
 RUN apk add --no-cache \
     gcc \
@@ -16,7 +16,8 @@ RUN apk add --no-cache \
     py3-pip \
     zlib-dev \
     make \
-    cmake
+    cmake \
+    perl
 
 RUN git clone --recursive  --depth 1 --branch ${AWSCLI_VERSION} --single-branch https://github.com/aws/aws-cli.git
 

--- a/package/alpine-full/Dockerfile
+++ b/package/alpine-full/Dockerfile
@@ -3,10 +3,19 @@
 ARG http_proxy
 ARG https_proxy
 
-FROM runiac/deploy:latest-alpine-azure
+FROM runiac/deploy:latest-alpine-aws
 
+ARG AZURE_CLI_VERSION=2.13.0
 ARG GCLOUD_CLI_VERSION=339.0.0
 ARG TARGETPLATFORM
+
+# install azure cli
+RUN \
+    apk update && \
+    apk add --no-cache curl tar openssl sudo bash jq python3 py-pip && \
+    apk add --virtual=build gcc libffi-dev musl-dev openssl-dev make python3-dev && \
+    python3 -m pip --no-cache-dir install azure-cli==${AZURE_CLI_VERSION} && \
+    apk del --purge build
 
 # install google cloud sdk
 RUN case ${TARGETPLATFORM} in \

--- a/package/alpine-gcp/Dockerfile
+++ b/package/alpine-gcp/Dockerfile
@@ -8,6 +8,8 @@ FROM runiac/deploy:latest-alpine
 ARG GCLOUD_CLI_VERSION=339.0.0
 ARG TARGETPLATFORM
 
+RUN apk add python3
+
 # install google cloud sdk
 RUN case ${TARGETPLATFORM} in \
          "linux/amd64")  GCLOUD_ARCH=linux-x86_64  ;; \


### PR DESCRIPTION
Add an initial `alpine-aws` image containing a copy of AWS CLI v2. Use this image as the "base" for our other derived images including `alpine-azure` and `alpine-gcp`, since it has minimal dependencies.

Future item: maybe we can look into reducing the size of the other images by avoiding the `python3` dependency altogether in favor multi-stage builds like this.

For reference: [aws/aws-cli#4685](https://github.com/aws/aws-cli/issues/4685).
