### PR TITLE
Upgrade Azure CLI to the latest.

### DIFF
--- a/package/alpine-azure/Dockerfile
+++ b/package/alpine-azure/Dockerfile
@@ -5,7 +5,7 @@ ARG https_proxy
 
 FROM runiac/deploy:latest-alpine
 
-ARG AZURE_CLI_VERSION=2.26.1
+ARG AZURE_CLI_VERSION=2.30.0
 
 # install azure cli
 RUN \


### PR DESCRIPTION
We should use the most recent version of Azure CLI by default.